### PR TITLE
Fix regex to ungreedy match for case when path contains ":"

### DIFF
--- a/lib/ab-result-parser.js
+++ b/lib/ab-result-parser.js
@@ -70,7 +70,7 @@ function getGenreralData(hash) {
 
 function getHash(data) {
     const result = {};
-    const regex = /(.+):(.+)/g;
+    const regex = /(.+?):(.+)/g;
     let m;
     while ((m = regex.exec(data)) !== null) {
         if (m.index === regex.lastIndex) {


### PR DESCRIPTION
This handles the case when URL contains ":".
Before changes the path will be wrongly show up as empty.
